### PR TITLE
✨ feat: implement logout confirmation modal in SideBar component

### DIFF
--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -1,31 +1,36 @@
 import { useRouter } from "expo-router";
 import React, { useState } from "react";
-import { Text, TouchableOpacity, View } from "react-native";
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { useAuthStore } from "../store/authStore";
 
 const SideBar = () => {
   const [selected, setSelected] = useState("home");
+  const [openModal, setOpenModal] = useState(false);
   const router = useRouter();
 
   const userName = useAuthStore((state) => state.user?.name);
+  const logout = useAuthStore((state) => state.logout);
+
   const handleSelect = (item: string) => {
     setSelected(item);
-    switch (item) {
-      case "home":
-        router.replace("/home");
-        break;
-      case "siplog":
-        router.replace("/siplog");
-        break;
-      case "settings":
-        router.replace("/settings");
-        break;
-      case "logout":
-        router.replace("/logout");
-        break;
-      default:
-        break;
+    if (item === "logout") {
+      setOpenModal(true);
+    } else {
+      router.replace(`/${item}` as `/home` | `/siplog` | `/settings`);
     }
+  };
+
+  const confirmLogout = async () => {
+    await logout();
+    setOpenModal(false);
+    router.replace("/login");
   };
 
   const itemList = [
@@ -37,7 +42,13 @@ const SideBar = () => {
   return (
     <View>
       <TouchableOpacity onPress={() => router.replace("/profile")}>
-        <Text style={{ color: "#fff", fontSize: 20,fontFamily:"Jersey15_400Regular" }}>
+        <Text
+          style={{
+            color: "#fff",
+            fontSize: 20,
+            fontFamily: "Jersey15_400Regular",
+          }}
+        >
           Hi!
           <Text style={{ textDecorationLine: "underline" }}>{userName}</Text>
         </Text>
@@ -46,14 +57,103 @@ const SideBar = () => {
         <View key={item.id}>
           <Text
             onPress={() => handleSelect(item.id)}
-            style={{ color: "#fff", fontSize: 18, marginTop: 10 , fontFamily:"Jersey15_400Regular"}}
+            style={{
+              color: "#fff",
+              fontSize: 18,
+              marginTop: 10,
+              fontFamily: "Jersey15_400Regular",
+            }}
           >
             {item.name}
           </Text>
         </View>
       ))}
+
+      {openModal && (
+        <Modal
+          transparent
+          visible={openModal}
+          animationType="fade"
+          onRequestClose={() => setOpenModal(false)}
+        >
+          <View style={styles.modalContainer}>
+            <View style={styles.modalBox}>
+              <Text style={styles.modalText}>
+                Are you sure you want to logout?
+              </Text>
+              <View style={styles.buttonContainer}>
+                <Pressable style={styles.yesButton}>
+                  <Text onPress={confirmLogout} style={styles.yesText}>
+                    Yes
+                  </Text>
+                </Pressable>
+                <Pressable style={styles.noButton}>
+                  <Text
+                    onPress={() => setOpenModal(false)}
+                    style={styles.noText}
+                  >
+                    No
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </Modal>
+      )}
     </View>
   );
 };
 
 export default SideBar;
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  modalBox: {
+    width: 300,
+    height: 200,
+    backgroundColor: "#fff",
+    borderRadius: 10,
+    padding: 20,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modalText: {
+    fontSize: 18,
+    marginBottom: 20,
+    fontFamily: "Jersey15_400Regular",
+  },
+  buttonContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 20,
+    gap: 40,
+  },
+  yesButton: {
+    borderColor: "#ff2727",
+    borderWidth: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 5,
+  },
+  noButton: {
+    backgroundColor: "#ff2727",
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 5,
+  },
+  yesText: {
+    color: "#141414",
+    fontFamily: "Jersey15_400Regular",
+    fontSize: 18,
+  },
+  noText: {
+    color: "#fff",
+    fontFamily: "Jersey15_400Regular",
+    fontSize: 18,
+  },
+});


### PR DESCRIPTION
# Pull Request

## Description
Added a confirmation modal that appears when the user selects "Logout" from the sidebar. The modal prompts the user to confirm their intention with "Yes" or "No" options. Selecting "Yes" logs the user out and redirects to the login page; selecting "No" simply closes the modal.

## Why
To prevent accidental logouts and improve user experience by confirming critical actions before execution.

## Testing
- Steps to verify:
  1. Open the app and navigate to the sidebar.
  2. Tap the "Logout" menu item.
  3. Confirm that a modal appears asking for logout confirmation.
  4. Tap "Yes" → user should be logged out and redirected to /login.
  5. Tap "No" → modal should close without logging out.
- Environment: iPhone 14 Pro

## Linked Issues
Liked issue #8 